### PR TITLE
feat: add configurable notification system

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,98 +20,116 @@ The [WezTerm](https://wezfurlong.org/wezterm/) Sessions is a Lua script enhancem
 - **Edit Session State** Allows selecting which saved session to
   edit, the json file is opened in the `$EDITOR` environment variable, or `nvim` if not set.
 
-Edit a state can be useful if you find that the foreground processes of the session are not restored correctly.  
+Edit a state can be useful if you find that the foreground processes of the session are not restored correctly.
 In such cases you can manually set the `tty` string in the state file.
 
 ## Installation
 
 **Add to your wezterm config**
 
-   ```lua
-    local sessions = wezterm.plugin.require("https://github.com/abidibo/wezterm-sessions")
-    sessions.apply_to_config(config) -- optional, this adds default keybindings
-   ```
+```lua
+ local sessions = wezterm.plugin.require("https://github.com/abidibo/wezterm-sessions")
+ sessions.apply_to_config(config) -- optional, this adds default keybindings
+```
 
 ## Configuration
 
-1. **Event Bindings:** You can define your own keybindings:
+1. **Notification Settings:** You can configure notification behavior:
 
-    ```lua
-    -- there are the default ones
-    config.keys = {
-        {
-            key = 's',
-            mods = 'ALT',
-            action = act({ EmitEvent = "save_session" }),
-        },
-        {
-            key = 'l',
-            mods = 'ALT',
-            action = act({ EmitEvent = "load_session" }),
-        },
-        {
-            key = 'r',
-            mods = 'ALT',
-            action = act({ EmitEvent = "restore_session" }),
-        },
-        {
-            key = 'd',
-            mods = 'CTRL|SHIFT',
-            action = act({ EmitEvent = "delete_session" }),
-        },
-        {
-            key = 'e',
-            mods = 'CTRL|SHIFT',
-            action = act({ EmitEvent = "edit_session" }),
-        },
-    }
+   ```lua
+   local sessions = wezterm.plugin.require("https://github.com/abidibo/wezterm-sessions")
+   sessions.apply_to_config(config, {
+     notification_method = "toast", -- "toast" | "log" | "both" | "none"
+     notification_duration = 4000   -- Duration in milliseconds (for toast notifications)
+   })
    ```
 
-2. I also recommend to set up a keybinding for creating **named** workspaces or rename the current one:
+   - `notification_method` options:
+     - `"toast"` (default): Show toast notifications
+     - `"log"`: Write to WezTerm log only
+     - `"both"`: Show toast and write to log
+     - `"none"`: Disable all notifications
+   - `notification_duration`: How long toast notifications are displayed (milliseconds)
 
-    ````lua 
-    -- Rename current workspace
-    {
-        key = '$',
-        mods = 'CTRL|SHIFT',
-        action = act.PromptInputLine {
-            description = 'Enter new workspace name',
-            action = wezterm.action_callback(
-                function(window, pane, line)
-                    if line then
-                        wezterm.mux.rename_workspace(wezterm.mux.get_active_workspace(), line)
-                    end
-                end
-            ),
-        },
-    },
-    -- Prompt for a name to use for a new workspace and switch to it.
-    {
-        key = 'w',
-        mods = 'CTRL|SHIFT',
-        action = act.PromptInputLine {
-            description = wezterm.format {
-                { Attribute = { Intensity = 'Bold' } },
-                { Foreground = { AnsiColor = 'Fuchsia' } },
-                { Text = 'Enter name for new workspace' },
-            },
-            action = wezterm.action_callback(function(window, pane, line)
-                -- line will be `nil` if they hit escape without entering anything
-                -- An empty string if they just hit enter
-                -- Or the actual line of text they wrote
-                if line then
-                    window:perform_action(
-                        act.SwitchToWorkspace {
-                            name = line,
-                        },
-                        pane
-                    )
-                end
-            end),
-        },
-    },
-    ```
-   
+2. **Event Bindings:** You can define your own keybindings:
+
+   ```lua
+   -- there are the default ones
+   config.keys = {
+       {
+           key = 's',
+           mods = 'ALT',
+           action = act({ EmitEvent = "save_session" }),
+       },
+       {
+           key = 'l',
+           mods = 'ALT',
+           action = act({ EmitEvent = "load_session" }),
+       },
+       {
+           key = 'r',
+           mods = 'ALT',
+           action = act({ EmitEvent = "restore_session" }),
+       },
+       {
+           key = 'd',
+           mods = 'CTRL|SHIFT',
+           action = act({ EmitEvent = "delete_session" }),
+       },
+       {
+           key = 'e',
+           mods = 'CTRL|SHIFT',
+           action = act({ EmitEvent = "edit_session" }),
+       },
+   }
+   ```
+
+3. I also recommend to set up a keybinding for creating **named** workspaces or rename the current one:
+
+   ````lua
+   -- Rename current workspace
+   {
+       key = '$',
+       mods = 'CTRL|SHIFT',
+       action = act.PromptInputLine {
+           description = 'Enter new workspace name',
+           action = wezterm.action_callback(
+               function(window, pane, line)
+                   if line then
+                       wezterm.mux.rename_workspace(wezterm.mux.get_active_workspace(), line)
+                   end
+               end
+           ),
+       },
+   },
+   -- Prompt for a name to use for a new workspace and switch to it.
+   {
+       key = 'w',
+       mods = 'CTRL|SHIFT',
+       action = act.PromptInputLine {
+           description = wezterm.format {
+               { Attribute = { Intensity = 'Bold' } },
+               { Foreground = { AnsiColor = 'Fuchsia' } },
+               { Text = 'Enter name for new workspace' },
+           },
+           action = wezterm.action_callback(function(window, pane, line)
+               -- line will be `nil` if they hit escape without entering anything
+               -- An empty string if they just hit enter
+               -- Or the actual line of text they wrote
+               if line then
+                   window:perform_action(
+                       act.SwitchToWorkspace {
+                           name = line,
+                       },
+                       pane
+                   )
+               end
+           end),
+       },
+   },
+   ```
+   ````
+
 ## Events
 
 The following events are emitted:
@@ -131,15 +149,15 @@ The following events are emitted:
 There are currently some limitations and improvements that need to be implemented:
 
 - The script is a fork of the original [WezTerm Session Manager](https://github.com/danielcopper/wezterm-session-manager) created by [Daniel Copper](https://github.com/danielcopper),
-which had some limitations I tried to fix, but also it was tested both on linux and windows. On the contrary I'm only interested on linux and so new functionality won't be tested on windows (if windows users are willing to help, they're welcome).
-- The script tries to restore the running processes (only on mac/linux) in each pane, and it does this by inspecting the `proc` `cmdline` file. Probably this can be improved and probably 
-not all processes can be restored succesfully.
+  which had some limitations I tried to fix, but also it was tested both on linux and windows. On the contrary I'm only interested on linux and so new functionality won't be tested on windows (if windows users are willing to help, they're welcome).
+- The script tries to restore the running processes (only on mac/linux) in each pane, and it does this by inspecting the `proc` `cmdline` file. Probably this can be improved and probably
+  not all processes can be restored succesfully.
 - The script does not treat remote sessions in a special way at the moment, and for what I read, there are some differences in WezTerm available infos for remote sessions. So maybe this doesn't work well in this scenario. It works well on local and unix domains.
 - The script should be able to restore even complex workspaces layouts, but who knows :)
 
 ## Credits
 
-This project is now developed by [abidibo](https://github.com/abidibo). 
+This project is now developed by [abidibo](https://github.com/abidibo).
 
 It is a fork of the original [WezTerm Session Manager](https://github.com/danielcopper/wezterm-session-manager) created by [Daniel Copper](https://github.com/danielcopper).
 

--- a/plugin/fs.lua
+++ b/plugin/fs.lua
@@ -12,68 +12,68 @@ local separator = is_windows and "\\" or "/"
 -- @param file_path string: The file path where the JSON file will be saved.
 -- @return boolean: true if saving was successful, false otherwise.
 function fs.save_to_json_file(data, file_path)
-    if not data then
-        wezterm.log_info("No workspace data to log.")
-        return false
-    end
+  if not data then
+    wezterm.log_info("No workspace data to log.")
+    return false
+  end
 
-    local file = io.open(file_path, "w")
-    if file then
-        file:write(wezterm.json_encode(data))
-        file:close()
-        return true
-    else
-        return false
-    end
+  local file = io.open(file_path, "w")
+  if file then
+    file:write(wezterm.json_encode(data))
+    file:close()
+    return true
+  else
+    return false
+  end
 end
 
 --- Loads data from a JSON file.
 -- @param file_path string: The file path from which the JSON data will be loaded.
 -- @return table or nil: The loaded data as a Lua table, or nil if loading failed.
 function fs.load_from_json_file(file_path)
-    local file = io.open(file_path, "r")
-    if not file then
-        wezterm.log_info("Failed to open file: " .. file_path)
-        return nil
-    end
+  local file = io.open(file_path, "r")
+  if not file then
+    wezterm.log_info("Failed to open file: " .. file_path)
+    return nil
+  end
 
-    local file_content = file:read("*a")
-    file:close()
+  local file_content = file:read("*a")
+  file:close()
 
-    local data = wezterm.json_parse(file_content)
-    if not data then
-        wezterm.log_info("Failed to parse JSON data from file: " .. file_path)
-    end
-    return data
+  local data = wezterm.json_parse(file_content)
+  if not data then
+    wezterm.log_info("Failed to parse JSON data from file: " .. file_path)
+  end
+  return data
 end
 
 --- Deletes the JSON file.
 -- @param file_path string: The file path of the JSON file to be deleted.
 -- @return boolean: true if deletion was successful, false otherwise.
 function fs.delete_json_file(file_path)
-    return os.remove(file_path)
+  return os.remove(file_path)
 end
 
 --- Returns the escaped file name: os separator must be escaped if using it in the file name
 --- @param file_name string
 --- @return string
 function fs.escape_file_name(file_name)
-    local s = file_name:gsub(separator, "+")
-    return s
+  local s = file_name:gsub(separator, "+")
+  return s
 end
 
 --- Returns the unescaped file name
 --- @param file_name string
 --- @return string
 function fs.unescape_file_name(file_name)
-    local s = file_name:gsub("+", separator)
-    return s
+  local s = file_name:gsub("+", separator)
+  return s
 end
 
 function fs.replace(str, what, with)
-    what = string.gsub(what, "[%(%)%.%+%-%*%?%[%]%^%$%%]", "%%%1") -- escape pattern
-    with = string.gsub(with, "[%%]", "%%%%") -- escape replacement
-    return string.gsub(str, what, with)
+  what = string.gsub(what, "[%(%)%.%+%-%*%?%[%]%^%$%%]", "%%%1") -- escape pattern
+  with = string.gsub(with, "[%%]", "%%%%") -- escape replacement
+  return string.gsub(str, what, with)
 end
 
 --- Retrieve the path from the working directory
@@ -81,24 +81,24 @@ end
 --- @param domain string
 --- @return string, number
 function fs.extract_path_from_dir(working_directory, domain)
-    local is_ssh = domain:find("SSHMUX", 1, true)
-    local hostname = wezterm.hostname()
+  local is_ssh = domain:find("SSHMUX", 1, true)
+  local hostname = wezterm.hostname()
 
-    if is_windows then -- TODO: windows
-        -- On Windows, transform 'file:///C:/path/to/dir' to 'C:/path/to/dir'
-        return working_directory:gsub("file:///", "")
-    elseif is_linux then
-        if not is_ssh then
-            -- local path
-            return fs.replace(working_directory, "file://" .. hostname, "")
-        else
-            -- ssh path
-            local ssh_host = domain:match("SSHMUX:(.*)")
-            return working_directory:gsub("file://" .. ssh_host, "")
-        end
-    else -- TODO: macOS
-        return working_directory:gsub("^.*(/Users/)", "/Users/")
+  if is_windows then -- TODO: windows
+    -- On Windows, transform 'file:///C:/path/to/dir' to 'C:/path/to/dir'
+    return working_directory:gsub("file:///", "")
+  elseif is_linux then
+    if not is_ssh then
+      -- local path
+      return fs.replace(working_directory, "file://" .. hostname, "")
+    else
+      -- ssh path
+      local ssh_host = domain:match("SSHMUX:(.*)")
+      return working_directory:gsub("file://" .. ssh_host, "")
     end
+  else -- TODO: macOS
+    return working_directory:gsub("^.*(/Users/)", "/Users/")
+  end
 end
 
 return fs

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -13,212 +13,228 @@ local separator = wezterm.target_triple:find("windows") and "\\" or "/"
 --- Checks if the plugin directory exists
 --- @return boolean
 local function directory_exists(path)
-    local success, result = pcall(wezterm.read_dir, plugin_dir .. path)
-    return success and result
+  local success, result = pcall(wezterm.read_dir, plugin_dir .. path)
+  return success and result
 end
 
 --- Returns the name of the package, used when requiring modules
 --- @return string
 local function get_require_path()
-    local path1 = "httpssCssZssZsgithubsDscomsZsabidibosZswezterm-sessions"
-    local path2 = "httpssCssZssZsgithubsDscomsZsabidibosZswezterm-sessionsZs"
-    return directory_exists(path2) and path2 or path1
+  local path1 = "httpssCssZssZsgithubsDscomsZsabidibosZswezterm-sessions"
+  local path2 = "httpssCssZssZsgithubsDscomsZsabidibosZswezterm-sessionsZs"
+  return directory_exists(path2) and path2 or path1
 end
 
 --- Adds the wezterm plugin directory to the lua path
 local function enable_sub_modules()
-    plugin_dir = wezterm.plugin.list()[1].plugin_dir:gsub(separator .. "[^" .. separator .. "]*$", "")
-    package.path = package.path
-        .. ";"
-        .. plugin_dir
-        .. separator
-        .. get_require_path()
-        .. separator
-        .. "plugin"
-        .. separator
-        .. "?.lua"
+  plugin_dir = wezterm.plugin.list()[1].plugin_dir:gsub(separator .. "[^" .. separator .. "]*$", "")
+  package.path = package.path
+    .. ";"
+    .. plugin_dir
+    .. separator
+    .. get_require_path()
+    .. separator
+    .. "plugin"
+    .. separator
+    .. "?.lua"
 end
 enable_sub_modules()
 
 --- Now we can import local stuff
 local ws_mod = require("workspace")
 local fs_mod = require("fs")
+local utils = require("utils")
+
+--- Default configuration
+local default_config = {
+  notification_method = "toast", -- "toast" | "log" | "both" | "none"
+  notification_duration = 2000,
+}
+
+--- Plugin configuration, will be merged with user options
+pub.config = default_config
 
 --- The directory where we store the workspaces state
 local save_state_dir = plugin_dir .. separator .. get_require_path() .. separator .. "state" .. separator
 
 --- Loads the saved json file matching the current workspace.
 function pub.restore_state(window)
-    local workspace_name = window:active_workspace()
-	wezterm.emit("wezterm-sessions.restore.start", workspace_name)
-    ws_mod.restore_workspace(window, save_state_dir, workspace_name)
-	wezterm.emit("wezterm-sessions.restore.end", workspace_name)
+  local workspace_name = window:active_workspace()
+  wezterm.emit("wezterm-sessions.restore.start", workspace_name)
+  ws_mod.restore_workspace(window, save_state_dir, workspace_name)
+  wezterm.emit("wezterm-sessions.restore.end", workspace_name)
 end
-
 
 --- Allows to select which workspace to load
 function pub.load_state(window, pane)
-    local choices = ws_mod.get_workspaces(save_state_dir)
+  local choices = ws_mod.get_workspaces(save_state_dir)
 
-    window:perform_action(
-        act.InputSelector({
-            action = wezterm.action_callback(function(_, inner_pane, id, label)
-                if id and label then
-	                wezterm.emit("wezterm-sessions.load.start", label)
-                    wezterm.log_info("Switching to ws: " .. label)
-                    -- switch to workspace
-                    window:perform_action(
-                        act.SwitchToWorkspace {
-                            name = label,
-                        },
-                        inner_pane
-                    )
-                    -- we need to wait for the switch to complete
-                    wezterm.sleep_ms(2000)
-                    window:perform_action(
-                        act.EmitEvent 'wezter-sessions-switch',
-                        pane
-                    )
-                end
-            end),
-            title = "Choose Workspace",
-            description = "Select a workspace and press Enter = accept, Esc = cancel, / = filter",
-            fuzzy_description = "Workspace to switch: ",
-            choices = choices,
-            fuzzy = true,
-        }),
-        pane
-    )
+  window:perform_action(
+    act.InputSelector({
+      action = wezterm.action_callback(function(_, inner_pane, id, label)
+        if id and label then
+          wezterm.emit("wezterm-sessions.load.start", label)
+          wezterm.log_info("Switching to ws: " .. label)
+          -- switch to workspace
+          window:perform_action(
+            act.SwitchToWorkspace({
+              name = label,
+            }),
+            inner_pane
+          )
+          -- we need to wait for the switch to complete
+          wezterm.sleep_ms(2000)
+          window:perform_action(act.EmitEvent("wezter-sessions-switch"), pane)
+        end
+      end),
+      title = "Choose Workspace",
+      description = "Select a workspace and press Enter = accept, Esc = cancel, / = filter",
+      fuzzy_description = "Workspace to switch: ",
+      choices = choices,
+      fuzzy = true,
+    }),
+    pane
+  )
 end
 
 --- After the workspace switch is complete we restore the workspace
 wezterm.on("wezter-sessions-switch", function(window, _)
-    local workspace_name = window:active_workspace()
-    pub.restore_state(window)
-	wezterm.emit("wezterm-sessions.load.end", workspace_name)
+  local workspace_name = window:active_workspace()
+  pub.restore_state(window)
+  wezterm.emit("wezterm-sessions.load.end", workspace_name)
 end)
 
 --- Orchestrator function to save the current workspace state.
 -- Collects workspace data, saves it to a JSON file, and displays a notification.
 function pub.save_state(window)
-    local data = ws_mod.retrieve_workspace_data(window)
+  local data = ws_mod.retrieve_workspace_data(window)
 
-    -- Construct the file path based on the workspace name
-    local file_path = save_state_dir .. "wezterm_state_" .. fs_mod.escape_file_name(data.name) .. ".json"
-	wezterm.emit("wezterm-sessions.save.start", file_path)
+  -- Construct the file path based on the workspace name
+  local file_path = save_state_dir .. "wezterm_state_" .. fs_mod.escape_file_name(data.name) .. ".json"
+  wezterm.emit("wezterm-sessions.save.start", file_path)
 
-    -- Save the workspace data to a JSON file and display the appropriate notification
-    local res = fs_mod.save_to_json_file(data, file_path)
-    if res then
-        window:toast_notification('WezTerm Sessions', 'Workspace state saved successfully', nil, 4000)
-    else
-        window:toast_notification('WezTerm Sessions', 'Failed to save workspace state', nil, 4000)
-    end
-	wezterm.emit("wezterm-sessions.save.end", file_path, res)
+  -- Save the workspace data to a JSON file and display the appropriate notification
+  local res = fs_mod.save_to_json_file(data, file_path)
+  if res then
+    window:toast_notification("WezTerm Sessions", "Workspace state saved successfully", nil, 4000)
+  else
+    window:toast_notification("WezTerm Sessions", "Failed to save workspace state", nil, 4000)
+  end
+  wezterm.emit("wezterm-sessions.save.end", file_path, res)
 end
 
 --- Allows to select which workspace to delete
 function pub.delete_state(window, pane)
-    local choices = ws_mod.get_workspaces(save_state_dir)
+  local choices = ws_mod.get_workspaces(save_state_dir)
 
-    window:perform_action(
-        act.InputSelector({
-            action = wezterm.action_callback(function(_, _, id, label)
-                if id and label then
-                    wezterm.log_info("Deleting ws: " .. label)
-                    local file_path = save_state_dir .. "wezterm_state_" .. fs_mod.escape_file_name(label) .. ".json"
-	                wezterm.emit("wezterm-sessions.delete.start", file_path)
+  window:perform_action(
+    act.InputSelector({
+      action = wezterm.action_callback(function(_, _, id, label)
+        if id and label then
+          wezterm.log_info("Deleting ws: " .. label)
+          local file_path = save_state_dir .. "wezterm_state_" .. fs_mod.escape_file_name(label) .. ".json"
+          wezterm.emit("wezterm-sessions.delete.start", file_path)
 
-                    local res = fs_mod.delete_json_file(file_path)
-                    if res then
-                        window:toast_notification('WezTerm Sessions', 'Workspace state deleted successfully', nil, 4000)
-                    else
-                        window:toast_notification('WezTerm Sessions', 'Failed to delete workspace state', nil, 4000)
-                    end
-	                wezterm.emit("wezterm-sessions.delete.end", file_path, res)
-                end
-            end),
-            title = "Choose Workspace to delete",
-            description = "Select a workspace and press Enter = accept, Esc = cancel, / = filter",
-            fuzzy_description = "Workspace to delete: ",
-            choices = choices,
-            fuzzy = true,
-        }),
-        pane
-    )
+          local res = fs_mod.delete_json_file(file_path)
+          if res then
+            window:toast_notification("WezTerm Sessions", "Workspace state deleted successfully", nil, 4000)
+          else
+            window:toast_notification("WezTerm Sessions", "Failed to delete workspace state", nil, 4000)
+          end
+          wezterm.emit("wezterm-sessions.delete.end", file_path, res)
+        end
+      end),
+      title = "Choose Workspace to delete",
+      description = "Select a workspace and press Enter = accept, Esc = cancel, / = filter",
+      fuzzy_description = "Workspace to delete: ",
+      choices = choices,
+      fuzzy = true,
+    }),
+    pane
+  )
 end
 
 --- Allows to select which workspace state to edit in favourite editor
 function pub.edit_state(window, pane)
-    local choices = ws_mod.get_workspaces(save_state_dir)
+  local choices = ws_mod.get_workspaces(save_state_dir)
 
-    window:perform_action(
-        act.InputSelector({
-            action = wezterm.action_callback(function(_, inner_pane, id, label)
-                if id and label then
-                    wezterm.log_info("Editing ws: " .. label)
-                    local file_path = save_state_dir .. "wezterm_state_" .. fs_mod.escape_file_name(label) .. ".json"
-                    local editor = os.getenv("EDITOR")
-                    if not editor then
-                        editor = "nvim"
-                    end
-	                wezterm.emit("wezterm-sessions.edit.start", file_path, editor)
-                    local command = string.format("%s %s\n", editor, file_path)
-                    inner_pane:send_text(command)
-                end
-            end),
-            title = "Choose Workspace state to edit",
-            description = "Select a workspace and press Enter = accept, Esc = cancel, / = filter",
-            fuzzy_description = "Workspace to edit: ",
-            choices = choices,
-            fuzzy = true,
-        }),
-        pane
-    )
+  window:perform_action(
+    act.InputSelector({
+      action = wezterm.action_callback(function(_, inner_pane, id, label)
+        if id and label then
+          wezterm.log_info("Editing ws: " .. label)
+          local file_path = save_state_dir .. "wezterm_state_" .. fs_mod.escape_file_name(label) .. ".json"
+          local editor = os.getenv("EDITOR")
+          if not editor then
+            editor = "nvim"
+          end
+          wezterm.emit("wezterm-sessions.edit.start", file_path, editor)
+          local command = string.format("%s %s\n", editor, file_path)
+          inner_pane:send_text(command)
+        end
+      end),
+      title = "Choose Workspace state to edit",
+      description = "Select a workspace and press Enter = accept, Esc = cancel, / = filter",
+      fuzzy_description = "Workspace to edit: ",
+      choices = choices,
+      fuzzy = true,
+    }),
+    pane
+  )
 end
 
 ---Sets default keybindings
 function pub.apply_to_config(config)
-    if config == nil then
-        config = {}
-    end
+  if config == nil then
+    config = {}
+  end
 
-    if config.keys == nil then
-        config.keys = {}
-    end
+  if config.keys == nil then
+    config.keys = {}
+  end
 
-    table.insert(config.keys, {
-        key = 's',
-        mods = 'ALT',
-        action = act({ EmitEvent = "save_session" }),
-    })
-    table.insert(config.keys, {
-        key = 'l',
-        mods = 'ALT',
-        action = act({ EmitEvent = "load_session" }),
-    })
-    table.insert(config.keys, {
-        key = 'r',
-        mods = 'ALT',
-        action = act({ EmitEvent = "restore_session" }),
-    })
-    table.insert(config.keys, {
-        key = 'd',
-        mods = 'CTRL|SHIFT',
-        action = act({ EmitEvent = "delete_session" }),
-    })
-    table.insert(config.keys, {
-        key = 'e',
-        mods = 'CTRL|SHIFT',
-        action = act({ EmitEvent = "edit_session" }),
-    })
+  table.insert(config.keys, {
+    key = "s",
+    mods = "ALT",
+    action = act({ EmitEvent = "save_session" }),
+  })
+  table.insert(config.keys, {
+    key = "l",
+    mods = "ALT",
+    action = act({ EmitEvent = "load_session" }),
+  })
+  table.insert(config.keys, {
+    key = "r",
+    mods = "ALT",
+    action = act({ EmitEvent = "restore_session" }),
+  })
+  table.insert(config.keys, {
+    key = "d",
+    mods = "CTRL|SHIFT",
+    action = act({ EmitEvent = "delete_session" }),
+  })
+  table.insert(config.keys, {
+    key = "e",
+    mods = "CTRL|SHIFT",
+    action = act({ EmitEvent = "edit_session" }),
+  })
 end
 
 --- Event handlers
-wezterm.on("save_session", function(window) pub.save_state(window) end)
-wezterm.on("load_session", function(window, pane) pub.load_state(window, pane) end)
-wezterm.on("restore_session", function(window) pub.restore_state(window) end)
-wezterm.on("delete_session", function(window, pane) pub.delete_state(window, pane) end)
-wezterm.on("edit_session", function(window, pane) pub.edit_state(window, pane) end)
+wezterm.on("save_session", function(window)
+  pub.save_state(window)
+end)
+wezterm.on("load_session", function(window, pane)
+  pub.load_state(window, pane)
+end)
+wezterm.on("restore_session", function(window)
+  pub.restore_state(window)
+end)
+wezterm.on("delete_session", function(window, pane)
+  pub.delete_state(window, pane)
+end)
+wezterm.on("edit_session", function(window, pane)
+  pub.edit_state(window, pane)
+end)
 
 return pub

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -61,7 +61,7 @@ local save_state_dir = plugin_dir .. separator .. get_require_path() .. separato
 function pub.restore_state(window)
   local workspace_name = window:active_workspace()
   wezterm.emit("wezterm-sessions.restore.start", workspace_name)
-  ws_mod.restore_workspace(window, save_state_dir, workspace_name)
+  ws_mod.restore_workspace(window, save_state_dir, workspace_name, pub.config)
   wezterm.emit("wezterm-sessions.restore.end", workspace_name)
 end
 
@@ -116,9 +116,9 @@ function pub.save_state(window)
   -- Save the workspace data to a JSON file and display the appropriate notification
   local res = fs_mod.save_to_json_file(data, file_path)
   if res then
-    window:toast_notification("WezTerm Sessions", "Workspace state saved successfully", nil, 4000)
+    utils.notify(window, "Workspace state saved successfully", pub.config)
   else
-    window:toast_notification("WezTerm Sessions", "Failed to save workspace state", nil, 4000)
+    utils.notify(window, "Failed to save workspace state", pub.config)
   end
   wezterm.emit("wezterm-sessions.save.end", file_path, res)
 end
@@ -137,9 +137,9 @@ function pub.delete_state(window, pane)
 
           local res = fs_mod.delete_json_file(file_path)
           if res then
-            window:toast_notification("WezTerm Sessions", "Workspace state deleted successfully", nil, 4000)
+            utils.notify(window, "Workspace state deleted successfully", pub.config)
           else
-            window:toast_notification("WezTerm Sessions", "Failed to delete workspace state", nil, 4000)
+            utils.notify(window, "Failed to delete workspace state", pub.config)
           end
           wezterm.emit("wezterm-sessions.delete.end", file_path, res)
         end

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -183,8 +183,17 @@ function pub.edit_state(window, pane)
   )
 end
 
----Sets default keybindings
-function pub.apply_to_config(config)
+---Sets default keybindings and applies configuration options
+---@param config table: WezTerm configuration table
+---@param options table: Optional settings for the plugin
+function pub.apply_to_config(config, options)
+  -- Merge user options with default config
+  if options then
+    for k, v in pairs(options) do
+      pub.config[k] = v
+    end
+  end
+
   if config == nil then
     config = {}
   end

--- a/plugin/pane.lua
+++ b/plugin/pane.lua
@@ -1,44 +1,48 @@
 local wezterm = require("wezterm")
-local fs = require('fs')
-local utils = require('utils')
+local fs = require("fs")
+local utils = require("utils")
 local pub = {}
 
 --- Retrieve pane data
 -- @param pane_info table: The pane information table.
 -- @return table: The pane data table.
 function pub.retrieve_pane_data(pane_info)
-    wezterm.log_info(pane_info, pane_info.pane:get_foreground_process_name(), pane_info.pane:get_foreground_process_info())
+  wezterm.log_info(
+    pane_info,
+    pane_info.pane:get_foreground_process_name(),
+    pane_info.pane:get_foreground_process_info()
+  )
 
-    -- default command line from process name
-    local tty = tostring(pane_info.pane:get_foreground_process_name())
-    -- we try to read process infoo in cmdline proc file to get the full command
-    local pinfo = pane_info.pane:get_foreground_process_info()
-    if pinfo ~= nil then
-        local cmdline_path = "/proc/" .. pinfo.pid .. "/cmdline"
-        local file = io.open(cmdline_path, "r")
-        -- And if we find the file we use this as tty
-        if file then
-            local cmdline = file:read("*a")  -- Read the entire file
-            file:close()
-            -- Replace null characters with spaces
-            tty = cmdline:gsub("\0", " ")
-        end
+  -- default command line from process name
+  local tty = tostring(pane_info.pane:get_foreground_process_name())
+  -- we try to read process infoo in cmdline proc file to get the full command
+  local pinfo = pane_info.pane:get_foreground_process_info()
+  if pinfo ~= nil then
+    local cmdline_path = "/proc/" .. pinfo.pid .. "/cmdline"
+    local file = io.open(cmdline_path, "r")
+    -- And if we find the file we use this as tty
+    if file then
+      local cmdline = file:read("*a") -- Read the entire file
+      file:close()
+      -- Replace null characters with spaces
+      tty = cmdline:gsub("\0", " ")
     end
+  end
 
-    return {
-        pane_id = tostring(pane_info.pane:pane_id()),
-        index = pane_info.index,
-        is_active = pane_info.is_active,
-        is_zoomed = pane_info.is_zoomed,
-        left = pane_info.left,
-        top = pane_info.top,
-        width = pane_info.width,
-        height = pane_info.height,
-        pixel_width = pane_info.pixel_width,
-        pixel_height = pane_info.pixel_height,
-        cwd = tostring(pane_info.pane:get_current_working_dir()),
-        tty = tty
-    }
+  return {
+    pane_id = tostring(pane_info.pane:pane_id()),
+    index = pane_info.index,
+    is_active = pane_info.is_active,
+    is_zoomed = pane_info.is_zoomed,
+    left = pane_info.left,
+    top = pane_info.top,
+    width = pane_info.width,
+    height = pane_info.height,
+    pixel_width = pane_info.pixel_width,
+    pixel_height = pane_info.pixel_height,
+    cwd = tostring(pane_info.pane:get_current_working_dir()),
+    tty = tty,
+  }
 end
 
 --- Resoters a pane from the provided pane data.
@@ -47,21 +51,23 @@ end
 --- @param pane any: The pane to restore.
 --- @param pane_data table: The pane data table.
 function pub.restore_pane(_, pane, pane_data)
-    -- Restore TTY for Neovim on Linux
-    -- NOTE: cwd is handled differently on windows. maybe extend functionality for windows later
-    -- This could probably be handled better in general
-    if not (utils.is_windows()) then
-        if pane_data.tty:find("sh") or
-            pane_data.tty:find("cmd.exe") or
-            pane_data.tty:find("powershell.exe") or
-            pane_data.tty:find("pwsh.exe") or
-            pane_data.tty:find("nu") or
-            pane_data.tty:find("zsh") then
-            -- do nothing, we already have a shell
-        elseif pane_data.tty ~= "nil" then
-            pane:send_text(pane_data.tty .. "\n")
-        end
+  -- Restore TTY for Neovim on Linux
+  -- NOTE: cwd is handled differently on windows. maybe extend functionality for windows later
+  -- This could probably be handled better in general
+  if not (utils.is_windows()) then
+    if
+      pane_data.tty:find("sh")
+      or pane_data.tty:find("cmd.exe")
+      or pane_data.tty:find("powershell.exe")
+      or pane_data.tty:find("pwsh.exe")
+      or pane_data.tty:find("nu")
+      or pane_data.tty:find("zsh")
+    then
+      -- do nothing, we already have a shell
+    elseif pane_data.tty ~= "nil" then
+      pane:send_text(pane_data.tty .. "\n")
     end
+  end
 end
 
 return pub

--- a/plugin/tab.lua
+++ b/plugin/tab.lua
@@ -1,107 +1,107 @@
 local wezterm = require("wezterm")
-local fs = require('fs')
-local pane_mod = require('pane')
+local fs = require("fs")
+local pane_mod = require("pane")
 local pub = {}
 
 --- Retrieves tab data
 -- @param tab wezterm.Tab: The tab to retrieve data from.
 -- @return table: The tab data table.
 function pub.retrieve_tab_data(tab)
-    local tab_data = {
-        tab_id = tostring(tab:tab_id()),
-		title = tab:get_title(),
-        panes = {}
-    }
+  local tab_data = {
+    tab_id = tostring(tab:tab_id()),
+    title = tab:get_title(),
+    panes = {},
+  }
 
-    -- Iterate over panes in the current tab
-    for _, pane_info in ipairs(tab:panes_with_info()) do
-        -- Collect pane details, including layout and process information
-        local pane_data = pane_mod.retrieve_pane_data(pane_info)
-        table.insert(tab_data.panes, pane_data)
-    end
+  -- Iterate over panes in the current tab
+  for _, pane_info in ipairs(tab:panes_with_info()) do
+    -- Collect pane details, including layout and process information
+    local pane_data = pane_mod.retrieve_pane_data(pane_info)
+    table.insert(tab_data.panes, pane_data)
+  end
 
-    return tab_data
+  return tab_data
 end
 
 --- Restore a tab from the provided tab data.
 function pub.restore_tab(window, tab_data)
-    local initial_pane = window:active_pane()
-    local domain = initial_pane:get_domain_name()
-    local cwd_uri = tab_data.panes[1].cwd
-    local cwd_path = fs.extract_path_from_dir(cwd_uri, domain)
+  local initial_pane = window:active_pane()
+  local domain = initial_pane:get_domain_name()
+  local cwd_uri = tab_data.panes[1].cwd
+  local cwd_path = fs.extract_path_from_dir(cwd_uri, domain)
 
-    local new_tab = window:mux_window():spawn_tab({ cwd = cwd_path })
-    if not new_tab then
-        wezterm.log_info("Failed to create a new tab.")
-        return
-    end
+  local new_tab = window:mux_window():spawn_tab({ cwd = cwd_path })
+  if not new_tab then
+    wezterm.log_info("Failed to create a new tab.")
+    return
+  end
 
-	if tab_data.title then
-		new_tab:set_title(tab_data.title)
-	end
+  if tab_data.title then
+    new_tab:set_title(tab_data.title)
+  end
 
-    -- Activate the new tab before creating panes
-    new_tab:activate()
+  -- Activate the new tab before creating panes
+  new_tab:activate()
 
-    -- Recreate panes within this tab
-    pub.restore_panes(window, new_tab, tab_data)
-    -- for j, pane_data in ipairs(tab_data.panes) do
-    --     pane_mod.restore_pane(window, new_tab, tab_data, j, pane_data)
-    -- end
+  -- Recreate panes within this tab
+  pub.restore_panes(window, new_tab, tab_data)
+  -- for j, pane_data in ipairs(tab_data.panes) do
+  --     pane_mod.restore_pane(window, new_tab, tab_data, j, pane_data)
+  -- end
 end
 
 --- Finds the panel data of the nearest horizontal split of the provided pane data
 --- @returns spanel table, idx number: the found panel_data and its index
 local function find_horizontal_split(pdata, tab_data)
-    local spanel = nil
-    local idx = nil
-    for j, pane_data in ipairs(tab_data.panes) do
-        if pane_data.top == pdata.top and pane_data.left == (pdata.left + pdata.width + 1) then
-            spanel = pane_data
-            idx = j
-        end
+  local spanel = nil
+  local idx = nil
+  for j, pane_data in ipairs(tab_data.panes) do
+    if pane_data.top == pdata.top and pane_data.left == (pdata.left + pdata.width + 1) then
+      spanel = pane_data
+      idx = j
     end
-    return spanel, idx
+  end
+  return spanel, idx
 end
 
 --- Finds the panel data of the nearest vertical split of the provided pane data
 --- @returns spanel table, idx number: the found panel_data and its index
 local function find_vertical_split(pdata, tab_data)
-    local spanel = nil
-    local idx = nil
-    for j, pane_data in ipairs(tab_data.panes) do
-        if pane_data.left == pdata.left and pane_data.top == (pdata.top + pdata.height + 1) then
-            spanel = pane_data
-            idx = j
-        end
+  local spanel = nil
+  local idx = nil
+  for j, pane_data in ipairs(tab_data.panes) do
+    if pane_data.left == pdata.left and pane_data.top == (pdata.top + pdata.height + 1) then
+      spanel = pane_data
+      idx = j
     end
-    return spanel, idx
+  end
+  return spanel, idx
 end
 
 --- Retrieves the width of the tab (in cells unit)
 --- @param tab_data table: The tab data table.
 --- @return number: The width of the tab.
 local function get_tab_width(tab_data)
-    local width = 0
-    for _, pane_data in ipairs(tab_data.panes) do
-        if pane_data.top == 0 then
-            width = width + pane_data.width
-        end
+  local width = 0
+  for _, pane_data in ipairs(tab_data.panes) do
+    if pane_data.top == 0 then
+      width = width + pane_data.width
     end
-    return width
+  end
+  return width
 end
 
 --- Retrieves the height of the tab (in cells unit)
 --- @param tab_data table: The tab data table.
 --- @return number: The height of the tab.
 local function get_tab_height(tab_data)
-    local height = 0
-    for _, pane_data in ipairs(tab_data.panes) do
-        if pane_data.left == 0 then
-            height = height + pane_data.height
-        end
+  local height = 0
+  for _, pane_data in ipairs(tab_data.panes) do
+    if pane_data.left == 0 then
+      height = height + pane_data.height
     end
-    return height
+  end
+  return height
 end
 
 --- Splits the active pane horizontally
@@ -113,17 +113,17 @@ end
 --- @param panes table: The table of panes that have been restored so far.
 --- @param hpane table: The pane data of the pane that should be created splitting ipane
 local function split_horizontally(window, tab, tab_width, ipanes, ipane, panes, hpane)
-    wezterm.log_info("Split horizontally", ipane.top, ipane.left)
-    wezterm.log_info("Restoring pane", tab_width, ipane.left, hpane.left)
-    local available_width = tab_width - ipane.left
-    local new_pane = tab:active_pane():split({
-        direction = 'Right',
-        cwd = fs.extract_path_from_dir(hpane.cwd, tab:active_pane():get_domain_name()),
-        size = 1 - ((hpane.left - ipane.left) / available_width)
-    })
-    table.insert(ipanes, hpane)
-    table.insert(panes, new_pane)
-    pane_mod.restore_pane(window, new_pane, hpane)
+  wezterm.log_info("Split horizontally", ipane.top, ipane.left)
+  wezterm.log_info("Restoring pane", tab_width, ipane.left, hpane.left)
+  local available_width = tab_width - ipane.left
+  local new_pane = tab:active_pane():split({
+    direction = "Right",
+    cwd = fs.extract_path_from_dir(hpane.cwd, tab:active_pane():get_domain_name()),
+    size = 1 - ((hpane.left - ipane.left) / available_width),
+  })
+  table.insert(ipanes, hpane)
+  table.insert(panes, new_pane)
+  pane_mod.restore_pane(window, new_pane, hpane)
 end
 
 --- Splits the active pane vertically
@@ -135,24 +135,23 @@ end
 --- @param panes table: The table of panes that have been restored so far.
 --- @param vpane table: The pane data of the pane that should be created splitting ipane
 local function split_vertically(window, tab, tab_height, ipanes, ipane, panes, vpane)
-    wezterm.log_info("Split vertically", ipane.top, ipane.left)
-    local available_height = tab_height - ipane.top
-    local new_pane = tab:active_pane():split({
-        direction = 'Bottom',
-        cwd = fs.extract_path_from_dir(vpane.cwd, tab:active_pane():get_domain_name()),
-        size = 1 - ((vpane.top - ipane.top) / available_height)
-    })
-    table.insert(ipanes, vpane)
-    table.insert(panes, new_pane)
-    pane_mod.restore_pane(window, new_pane, vpane)
+  wezterm.log_info("Split vertically", ipane.top, ipane.left)
+  local available_height = tab_height - ipane.top
+  local new_pane = tab:active_pane():split({
+    direction = "Bottom",
+    cwd = fs.extract_path_from_dir(vpane.cwd, tab:active_pane():get_domain_name()),
+    size = 1 - ((vpane.top - ipane.top) / available_height),
+  })
+  table.insert(ipanes, vpane)
+  table.insert(panes, new_pane)
+  pane_mod.restore_pane(window, new_pane, vpane)
 end
 
 local function activate_panel(p)
-    wezterm.sleep_ms(200)
-    p:activate()
-    wezterm.sleep_ms(200)
+  wezterm.sleep_ms(200)
+  p:activate()
+  wezterm.sleep_ms(200)
 end
-
 
 --- Restores all tab panes from the provided tab data
 --- Algorithm:
@@ -161,46 +160,46 @@ end
 --- Then we split it horizontally and/or vertically in the found order
 --- The new created panes are stacked on a list and the process continues along the stack
 function pub.restore_panes(window, tab, tab_data)
-    -- keeps track of actually created panes data
-    local ipanes = { tab_data.panes[1] }
-    -- keeps track of restored panes
-    local panes = { tab:active_pane() }
+  -- keeps track of actually created panes data
+  local ipanes = { tab_data.panes[1] }
+  -- keeps track of restored panes
+  local panes = { tab:active_pane() }
 
-    -- Tab dimensions (in cell unit)
-    local tab_width = get_tab_width(tab_data)
-    local tab_height = get_tab_height(tab_data)
+  -- Tab dimensions (in cell unit)
+  local tab_width = get_tab_width(tab_data)
+  local tab_height = get_tab_height(tab_data)
 
-    -- Loop tp restore all panes
-    for idx, p in ipairs(panes) do
-        -- restore first pane
-        if idx == 1 then
-            pane_mod.restore_pane(window, p, tab_data.panes[1])
-        end
-
-        activate_panel(p)
-
-        -- Does the current pane have a horizontal or vertical split?
-        local hpane, hj = find_horizontal_split(ipanes[idx], tab_data)
-        local vpane, vj = find_vertical_split(ipanes[idx], tab_data)
-
-        -- Now we try to understand from splits indexes which split should be performed first
-        if hpane ~= nil and (vj == nil or vj < hj) then -- I though here should be vj < hj but it works this way
-            split_horizontally(window, tab, tab_width, ipanes, ipanes[idx], panes, hpane)
-            activate_panel(p)
-            if vpane ~= nil then
-                split_vertically(window, tab, tab_height, ipanes, ipanes[idx], panes, vpane)
-                activate_panel(p)
-            end
-        elseif vpane ~= nil then
-            split_vertically(window, tab, tab_height, ipanes, ipanes[idx], panes, vpane)
-            activate_panel(p)
-            if hpane ~= nil then
-                split_horizontally(window, tab, tab_width, ipanes, ipanes[idx], panes, hpane)
-            end
-        end
+  -- Loop tp restore all panes
+  for idx, p in ipairs(panes) do
+    -- restore first pane
+    if idx == 1 then
+      pane_mod.restore_pane(window, p, tab_data.panes[1])
     end
 
-    wezterm.log_info("Finished")
+    activate_panel(p)
+
+    -- Does the current pane have a horizontal or vertical split?
+    local hpane, hj = find_horizontal_split(ipanes[idx], tab_data)
+    local vpane, vj = find_vertical_split(ipanes[idx], tab_data)
+
+    -- Now we try to understand from splits indexes which split should be performed first
+    if hpane ~= nil and (vj == nil or vj < hj) then -- I though here should be vj < hj but it works this way
+      split_horizontally(window, tab, tab_width, ipanes, ipanes[idx], panes, hpane)
+      activate_panel(p)
+      if vpane ~= nil then
+        split_vertically(window, tab, tab_height, ipanes, ipanes[idx], panes, vpane)
+        activate_panel(p)
+      end
+    elseif vpane ~= nil then
+      split_vertically(window, tab, tab_height, ipanes, ipanes[idx], panes, vpane)
+      activate_panel(p)
+      if hpane ~= nil then
+        split_horizontally(window, tab, tab_width, ipanes, ipanes[idx], panes, hpane)
+      end
+    end
+  end
+
+  wezterm.log_info("Finished")
 end
 
 return pub

--- a/plugin/utils.lua
+++ b/plugin/utils.lua
@@ -1,14 +1,26 @@
 local wezterm = require("wezterm")
+
 local utils = {}
 
---- Checks if the user is on Windows
 function utils.is_windows()
-    return wezterm.target_triple:find("windows") ~= nil
+  return wezterm.target_triple:find("windows") ~= nil
 end
 
---- Displays a notification with the specified message.
-function utils.notify(window, message)
-    return window:toast_notification('WezTerm', message, nil, 2000)
+--- Displays a notification with the specified message based on configuration.
+--- @param window wezterm.Window: The window to display the notification in
+--- @param message string: The message to display
+--- @param config table: Optional configuration table with notification_method and notification_duration
+function utils.notify(window, message, config)
+  local method = config and config.notification_method or "toast"
+  local duration = config and config.notification_duration or 2000
+
+  if method == "toast" or method == "both" then
+    window:toast_notification("WezTerm Sessions", message, nil, duration)
+  end
+
+  if method == "log" or method == "both" then
+    wezterm.log_info("[WezTerm Sessions] " .. message)
+  end
 end
 
 return utils

--- a/plugin/window.lua
+++ b/plugin/window.lua
@@ -1,56 +1,58 @@
 local wezterm = require("wezterm")
-local tab_mod = require('tab')
+local tab_mod = require("tab")
 local pub = {}
 
 --- Retrieves the current window data from the provided mux window.
 -- @param mux_window wezterm.MuxWindow: The mux window to retrieve the window data from.
 -- @return table: The window data table.
 function pub.retrieve_window_data(mux_window)
-    local win_data = {
-        title = mux_window:get_title(),
-        tabs = {}
-    }
+  local win_data = {
+    title = mux_window:get_title(),
+    tabs = {},
+  }
 
-    -- Iterate over tabs in the current window
-    for _, tab in ipairs(mux_window:tabs()) do
-        local tab_data = tab_mod.retrieve_tab_data(tab)
-        table.insert(win_data.tabs, tab_data)
-    end
+  -- Iterate over tabs in the current window
+  for _, tab in ipairs(mux_window:tabs()) do
+    local tab_data = tab_mod.retrieve_tab_data(tab)
+    table.insert(win_data.tabs, tab_data)
+  end
 
-    return win_data
+  return win_data
 end
 
 --- Restore a window from the provided window data.
 function pub.restore_window(window, win_data)
-    local initial_pane = window:active_pane()
-    local foreground_process = initial_pane:get_foreground_process_name()
-    wezterm.log_info("Restoring window panel domain", initial_pane:get_domain_name())
-    wezterm.log_info("Restoring window panel hostname", wezterm.hostname())
+  local initial_pane = window:active_pane()
+  local foreground_process = initial_pane:get_foreground_process_name()
+  wezterm.log_info("Restoring window panel domain", initial_pane:get_domain_name())
+  wezterm.log_info("Restoring window panel hostname", wezterm.hostname())
 
-    local domain = initial_pane:get_domain_name()
-    if not domain:find("SSHMUX", 1, true) then
-        -- Check if the foreground process is a shell
-        if foreground_process then
-            if foreground_process:find("sh") or
-                foreground_process:find("cmd.exe") or
-                foreground_process:find("powershell.exe") or
-                foreground_process:find("pwsh.exe") or
-                foreground_process:find("nu") or
-                foreground_process:find("zsh") then
-                -- Safe to close
-                initial_pane:send_text("exit\r")
-            else
-                wezterm.log_info("Active program detected. Skipping exit command for initial pane.")
-            end
-        else
-            -- Safe to close
-            initial_pane:send_text("exit\r")
-        end
+  local domain = initial_pane:get_domain_name()
+  if not domain:find("SSHMUX", 1, true) then
+    -- Check if the foreground process is a shell
+    if foreground_process then
+      if
+        foreground_process:find("sh")
+        or foreground_process:find("cmd.exe")
+        or foreground_process:find("powershell.exe")
+        or foreground_process:find("pwsh.exe")
+        or foreground_process:find("nu")
+        or foreground_process:find("zsh")
+      then
+        -- Safe to close
+        initial_pane:send_text("exit\r")
+      else
+        wezterm.log_info("Active program detected. Skipping exit command for initial pane.")
+      end
+    else
+      -- Safe to close
+      initial_pane:send_text("exit\r")
     end
+  end
 
-    for _, tab_data in ipairs(win_data.tabs) do
-        tab_mod.restore_tab(window, tab_data)
-    end
+  for _, tab_data in ipairs(win_data.tabs) do
+    tab_mod.restore_tab(window, tab_data)
+  end
 end
 
 return pub

--- a/plugin/workspace.lua
+++ b/plugin/workspace.lua
@@ -1,7 +1,7 @@
 local wezterm = require("wezterm")
-local fs = require('fs')
-local win_mod = require('window')
-local utils = require('utils')
+local fs = require("fs")
+local win_mod = require("window")
+local utils = require("utils")
 
 local pub = {}
 
@@ -9,90 +9,94 @@ local pub = {}
 -- @param window wezterm.Window: The active window to retrieve the workspace data from.
 -- @return table or nil: The workspace data table or nil if no active window is found.
 function pub.retrieve_workspace_data(window)
-    local workspace_name = window:active_workspace()
-    local workspace_data = {
-        name = workspace_name,
-        windows = {}
-    }
+  local workspace_name = window:active_workspace()
+  local workspace_data = {
+    name = workspace_name,
+    windows = {},
+  }
 
-    -- Iterale over windows
-    for _, mux_win in ipairs(wezterm.mux.all_windows()) do
-        if mux_win:get_workspace() == workspace_name then
-            local win_data = win_mod.retrieve_window_data(mux_win)
-            table.insert(workspace_data.windows, win_data)
-        end
+  -- Iterale over windows
+  for _, mux_win in ipairs(wezterm.mux.all_windows()) do
+    if mux_win:get_workspace() == workspace_name then
+      local win_data = win_mod.retrieve_window_data(mux_win)
+      table.insert(workspace_data.windows, win_data)
     end
+  end
 
-    return workspace_data
+  return workspace_data
 end
 
 --- Recreates the workspace based on the provided data.
 -- @param window wezterm.Window: The active window to recreate the workspace in.
 -- @param workspace_name string: The name of the workspace to recreate.
 -- @param workspace_data table: The data structure containing the saved workspace state.
-function pub.recreate_workspace(window, workspace_name, workspace_data)
-    if not workspace_data or not workspace_data.windows then
-        wezterm.log_info("Invalid or empty workspace data provided.")
-        return
-    end
+-- @param config table: Optional configuration table with notification settings
+function pub.recreate_workspace(window, workspace_name, workspace_data, config)
+  if not workspace_data or not workspace_data.windows then
+    wezterm.log_info("Invalid or empty workspace data provided.")
+    return
+  end
 
-    local tabs = window:mux_window():tabs()
+  local tabs = window:mux_window():tabs()
 
-    if #tabs ~= 1 or #tabs[1]:panes() ~= 1 then
-        wezterm.log_info("Restoration can only be performed in a window with a single tab and a single pane")
-        utils.notify(window, 'Restoration can only be performed in a window with a single tab and a single pane')
-        return
-    end
+  if #tabs ~= 1 or #tabs[1]:panes() ~= 1 then
+    wezterm.log_info("Restoration can only be performed in a window with a single tab and a single pane")
+    utils.notify(window, "Restoration can only be performed in a window with a single tab and a single pane", config)
+    return
+  end
 
-    -- Recreate windows tabs and panes from the saved state
-    for idx, win_data in ipairs(workspace_data.windows) do
-        if idx == 1 then
-            -- The first window will be restored in the current window
-            win_mod.restore_window(window, win_data)
-        else
-            -- All other windows will be spawned in a new window
-            local _, _, w = wezterm.mux.spawn_window({
-                workspace = workspace_name,
-            })
-            win_mod.restore_window(w:gui_window(), win_data)
-        end
+  -- Recreate windows tabs and panes from the saved state
+  for idx, win_data in ipairs(workspace_data.windows) do
+    if idx == 1 then
+      -- The first window will be restored in the current window
+      win_mod.restore_window(window, win_data)
+    else
+      -- All other windows will be spawned in a new window
+      local _, _, w = wezterm.mux.spawn_window({
+        workspace = workspace_name,
+      })
+      win_mod.restore_window(w:gui_window(), win_data)
     end
 
     wezterm.log_info("Workspace recreated with new tabs and panes based on saved state.")
-    return true
+  end
 end
 
 --- Restores a workspace name
-function pub.restore_workspace(window, dir, workspace_name)
-    wezterm.log_info("Restoring state for workspace: " .. workspace_name)
-    local file_path = dir .. "wezterm_state_" .. fs.escape_file_name(workspace_name) .. ".json"
+-- @param window wezterm.Window: The active window
+-- @param dir string: Directory where workspace states are stored
+-- @param workspace_name string: Name of the workspace to restore
+-- @param config table: Optional configuration table with notification settings
+function pub.restore_workspace(window, dir, workspace_name, config)
+  wezterm.log_info("Restoring state for workspace: " .. workspace_name)
+  local file_path = dir .. "wezterm_state_" .. fs.escape_file_name(workspace_name) .. ".json"
 
-    local workspace_data = fs.load_from_json_file(file_path)
-    if not workspace_data then
-        utils.notify(window, 'Workspace state file not found for workspace: ' .. workspace_name)
-        return
-    end
+  local workspace_data = fs.load_from_json_file(file_path)
+  if not workspace_data then
+    utils.notify(window, "Workspace state file not found for workspace: " .. workspace_name, config)
+    return
+  end
 
-    if pub.recreate_workspace(window, workspace_name, workspace_data) then
-        utils.notify(window, 'Workspace state loaded for workspace: ' .. workspace_name)
-    else
-        utils.notify(window, 'Workspace state loading failed for workspace: ' .. workspace_name)
-    end
+  if pub.recreate_workspace(window, workspace_name, workspace_data, config) then
+    utils.notify(window, "Workspace state loaded for workspace: " .. workspace_name, config)
+  else
+    utils.notify(window, "Workspace state loading failed for workspace: " .. workspace_name, config)
+  end
 end
 
 --- Returns the list of available workspaces
 --- @param dir string
 --- @return table
 function pub.get_workspaces(dir)
-    local choices = {}
-    for d in io.popen("ls -pa " .. dir .. " | grep -v /"):lines() do
-        if string.find(d, "wezterm_state_") then
-            local w = d:gsub("wezterm_state_", "")
-            w = w:gsub(".json", "")
-            table.insert(choices, { id = d, label = fs.unescape_file_name(w) })
-        end
+  local choices = {}
+  for d in io.popen("ls -pa " .. dir .. " | grep -v /"):lines() do
+    if string.find(d, "wezterm_state_") then
+      local w = d:gsub("wezterm_state_", "")
+      w = w:gsub(".json", "")
+      table.insert(choices, { id = d, label = fs.unescape_file_name(w) })
     end
-    return choices
+  end
+  return choices
 end
 
 return pub


### PR DESCRIPTION
## Summary

This PR adds a configurable notification system, allowing users to customize how and when notifications are displayed. Users can now choose between toast notifications, log output, both, or disable notifications entirely, and can also configure the display duration for toast notifications.

## Changes

- Extended `utils.notify()` function to support configuration-based notification methods
- Updated `workspace.lua` notification calls to use configurable notifications
- Updated `init.lua` notification calls to use configurable notifications  
- Extended `apply_to_config()` method to accept optional configuration parameters
- Added comprehensive documentation and configuration examples to README

## Configuration Example

```lua
local sessions = wezterm.plugin.require("https://github.com/kubosho/wezterm-sessions")
sessions.apply_to_config(config, {
  notification_method = "toast", -- "toast" | "log" | "both" | "none"
  notification_duration = 4000   -- Duration in milliseconds
})
```
