### PR TITLE
refactor: unify Windows detection using wezterm.target_triple:find('windows')

### DIFF
--- a/plugin/fs.lua
+++ b/plugin/fs.lua
@@ -101,7 +101,4 @@ function fs.extract_path_from_dir(working_directory, domain)
     end
 end
 
---- Export is_windows for backward compatibility
-fs.is_windows = is_windows
-
 return fs

--- a/plugin/fs.lua
+++ b/plugin/fs.lua
@@ -1,8 +1,9 @@
 local wezterm = require("wezterm")
+local utils = require("utils")
 local fs = {}
 
---- checks if the user is on windows
-local is_windows = wezterm.target_triple == "x86_64-pc-windows-msvc"
+--- checks if the user is on windows/linux
+local is_windows = utils.is_windows()
 local is_linux = wezterm.target_triple == "x86_64-unknown-linux-gnu"
 local separator = is_windows and "\\" or "/"
 
@@ -99,5 +100,8 @@ function fs.extract_path_from_dir(working_directory, domain)
         return working_directory:gsub("^.*(/Users/)", "/Users/")
     end
 end
+
+--- Export is_windows for backward compatibility
+fs.is_windows = is_windows
 
 return fs

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -7,9 +7,8 @@ local pub = {}
 --- wezterm plugin directory
 local plugin_dir
 
---- checks if the user is on windows
-local is_windows = wezterm.target_triple == "x86_64-pc-windows-msvc"
-local separator = is_windows and "\\" or "/"
+--- OS path separator
+local separator = wezterm.target_triple:find("windows") and "\\" or "/"
 
 --- Checks if the plugin directory exists
 --- @return boolean

--- a/plugin/pane.lua
+++ b/plugin/pane.lua
@@ -1,5 +1,6 @@
 local wezterm = require("wezterm")
 local fs = require('fs')
+local utils = require('utils')
 local pub = {}
 
 --- Retrieve pane data
@@ -49,7 +50,7 @@ function pub.restore_pane(_, pane, pane_data)
     -- Restore TTY for Neovim on Linux
     -- NOTE: cwd is handled differently on windows. maybe extend functionality for windows later
     -- This could probably be handled better in general
-    if not (fs.is_windows) then
+    if not (utils.is_windows()) then
         if pane_data.tty:find("sh") or
             pane_data.tty:find("cmd.exe") or
             pane_data.tty:find("powershell.exe") or

--- a/plugin/utils.lua
+++ b/plugin/utils.lua
@@ -1,4 +1,10 @@
+local wezterm = require("wezterm")
 local utils = {}
+
+--- Checks if the user is on Windows
+function utils.is_windows()
+    return wezterm.target_triple:find("windows") ~= nil
+end
 
 --- Displays a notification with the specified message.
 function utils.notify(window, message)

--- a/plugin/workspace.lua
+++ b/plugin/workspace.lua
@@ -5,9 +5,6 @@ local utils = require('utils')
 
 local pub = {}
 
---- Checks if the user is on windows
-local is_windows = wezterm.target_triple == "x86_64-pc-windows-msvc"
-
 --- Retrieves the current workspace data from the active window.
 -- @param window wezterm.Window: The active window to retrieve the workspace data from.
 -- @return table or nil: The workspace data table or nil if no active window is found.


### PR DESCRIPTION
## Summary

Unified Windows platform detection across the codebase by centralizing the logic in the `utils` module. This improves maintainability by having a single source of truth for Windows detection.

## Changes

- Added `is_windows()` function to `utils.lua` using the more flexible `wezterm.target_triple:find('windows')` pattern
- Updated `fs.lua` to use `utils.is_windows()` while maintaining backward compatibility
- Updated `pane.lua` to use `utils.is_windows()` instead of `fs.is_windows`
- Removed unused Windows detection in `workspace.lua`

## Benefits

- Centralized Windows detection logic in one place
- More flexible detection that works with any Windows target triple variant
- Easier to maintain and update platform detection in the future
- Consistent detection method across all modules