### PR TITLE
fix: correct require paths for plugin modules

### DIFF
--- a/plugin/pane.lua
+++ b/plugin/pane.lua
@@ -1,6 +1,6 @@
 local wezterm = require("wezterm")
-local fs = require("fs")
-local utils = require("utils")
+local fs = require("plugin.fs")
+local utils = require("plugin.utils")
 local pub = {}
 
 --- Retrieve pane data

--- a/plugin/tab.lua
+++ b/plugin/tab.lua
@@ -1,6 +1,9 @@
 local wezterm = require("wezterm")
 local fs = require("plugin.fs")
+wezterm.log_info("Loading pane module...")
 local pane_mod = require("plugin.pane")
+wezterm.log_info("Pane module loaded:", pane_mod)
+wezterm.log_info("retrieve_pane_data function:", pane_mod.retrieve_pane_data)
 local pub = {}
 
 --- Retrieves tab data

--- a/plugin/tab.lua
+++ b/plugin/tab.lua
@@ -1,6 +1,6 @@
 local wezterm = require("wezterm")
-local fs = require("fs")
-local pane_mod = require("pane")
+local fs = require("plugin.fs")
+local pane_mod = require("plugin.pane")
 local pub = {}
 
 --- Retrieves tab data

--- a/plugin/window.lua
+++ b/plugin/window.lua
@@ -1,5 +1,5 @@
 local wezterm = require("wezterm")
-local tab_mod = require("tab")
+local tab_mod = require("plugin.tab")
 local pub = {}
 
 --- Retrieves the current window data from the provided mux window.

--- a/plugin/workspace.lua
+++ b/plugin/workspace.lua
@@ -1,7 +1,7 @@
 local wezterm = require("wezterm")
-local fs = require("fs")
-local win_mod = require("window")
-local utils = require("utils")
+local fs = require("plugin.fs")
+local win_mod = require("plugin.window")
+local utils = require("plugin.utils")
 
 local pub = {}
 


### PR DESCRIPTION
## Summary

Fixes module loading errors that occur during `save_session` events. The plugin was experiencing `attempt to call a nil value (field 'retrieve_pane_data')` errors due to incorrect require paths for internal modules.

## Technical Details

The original code used inconsistent require paths - some files used relative paths (e.g., `require('pane')`) while `init.lua` used the plugin-specific pattern. This inconsistency caused module loading failures when the plugin was loaded from remote repositories.

All require statements now consistently use the `plugin.` prefix pattern, which aligns with how the `enable_sub_modules()` function in `init.lua` sets up the lua package path.

## Fixes

- Resolves runtime errors during save_session events
- Ensures consistent module loading across all plugin files
- Maintains compatibility with existing plugin architecture